### PR TITLE
Fix CodeFund embed script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -700,8 +700,7 @@ Please make sure to update tests as appropriate.
         ></script>
 
         <script
-            id="codefund-script"
-            src="https://codefund.app/properties/144/funder.js?template=default"
+            src="https://app.codefund.io/properties/144/funder.js"
             async="async"
         ></script>
 


### PR DESCRIPTION
The `id="codefund-script"` prevented the ad from working for some reason. I have updated the script by removing the `id`, the template (which is controlled via CodeFund settings), and the URL.

/cc @dguo 