### PR TITLE
Remove Open Sans

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
-html {
-    font-family: "Open Sans", sans-serif;
+body {
+    font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 }
 
 /* stylelint-disable no-descending-specificity */

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "dev": "yarn install && next dev",
         "build": "next build",
         "export": "next build && next export -o build",
-        "format": "prettier --write package.json public/*.js public/*.css",
-        "format:check": "prettier --list-different package.json public/*.js public/*.css",
+        "format": "prettier --write package.json public/*.js index.css",
+        "format:check": "prettier --list-different package.json public/*.js index.css",
         "lint": "yarn run lint:css",
         "lint:css": "stylelint ./**/*.css"
     },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import "../index.css";
+
+export default function App({Component, pageProps}) {
+    return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,17 +68,12 @@ export default function Home() {
                 />
                 <link
                     rel="stylesheet"
-                    href="https://fonts.googleapis.com/css?family=Open+Sans"
-                />
-                <link
-                    rel="stylesheet"
                     href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css"
                 />
                 <link
                     rel="stylesheet"
                     href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/hopscotch.min.css"
                 />
-                <link rel="stylesheet" href="index.css" />
             </Head>
 
             <GitHubCorner


### PR DESCRIPTION
It turns out we were loading it but never actually using it because Bulma's font family line was overriding ours. Helvetica looks better than the Google Fonts ones that I tried, so let's just stick with that and save some bandwidth in the process by not loading our own font.