### PR TITLE
Add a form label

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -250,9 +250,12 @@ export default function Home() {
                 <div className="columns">
                     <div className="column is-6">
                         <h3 className="title is-4 has-text-centered has-text-light">
-                            Markdown Input (editable)
+                            <label htmlFor="markdown-input">
+                                Markdown Input (editable)
+                            </label>
                         </h3>
                         <textarea
+                            id="markdown-input"
                             defaultValue={`
 # Foobar
 


### PR DESCRIPTION
Lighthouse caught this with a "Form elements do not have associated labels" violation:

<img width="856" alt="image" src="https://user-images.githubusercontent.com/2763135/124122545-34005380-da44-11eb-918b-b8e70cbf6c66.png">