### PR TITLE
Add spacing around overlapping tap targets

### DIFF
--- a/index.css
+++ b/index.css
@@ -33,6 +33,10 @@ p {
     margin-top: 1em;
 }
 
+ul {
+    line-height: 35px;
+}
+
 #footer {
     margin-bottom: 0px;
     padding-top: 2em;


### PR DESCRIPTION
Lighthouse caught this with a "Tap targets are not sized appropriately" violation:

<img width="889" alt="image" src="https://user-images.githubusercontent.com/2763135/124124392-5e531080-da46-11eb-9c7a-0aa2dae40931.png">
