### PR TITLE
Fix violations reported by markdownlint in the README.md template

### DIFF
--- a/components/Template.tsx
+++ b/components/Template.tsx
@@ -31,11 +31,13 @@ foobar.singularize('phenomena')
 \`\`\`
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 
 ## License
+
 [MIT](https://choosealicense.com/licenses/mit/)`;
 
 export function Template() {

--- a/components/Template.tsx
+++ b/components/Template.tsx
@@ -32,7 +32,8 @@ foobar.singularize('phenomena')
 
 ## Contributing
 
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+Pull requests are welcome. For major changes, please open an issue first
+to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 


### PR DESCRIPTION
Fixes violations reported by [markdownlint](https://github.com/DavidAnson/markdownlint) in [the Markdown template](https://www.makeareadme.com/#template-1):
* [MD013 - Line length](https://github.com/DavidAnson/markdownlint/blob/v0.26.2/doc/Rules.md#md013),
* [MD022 - Headings should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.26.2/doc/Rules.md#md022)