### PR TITLE
Fix Markdown rendering when dark mode is on

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import "github-markdown-css/github-markdown.css";
+import "github-markdown-css/github-markdown-light.css";
 import "../global.css";
 
 import "@fortawesome/fontawesome-svg-core/styles.css";


### PR DESCRIPTION
A Firefox update set my website appearance setting to automatic:
<img width="678" alt="image" src="https://github.com/dguo/make-a-readme/assets/2763135/92b9669e-dbea-475d-a3a3-3ed6175261ee">

Which led me to notice that the rendered Markdown has text that is hard to read when dark mode is on:
<img width="1041" alt="image" src="https://github.com/dguo/make-a-readme/assets/2763135/0464dd9b-7660-4126-94fe-90a91c5c8b98">

Because the default styling from `github-markdown-css` [reads](https://github.com/sindresorhus/github-markdown-css?tab=readme-ov-file#usage) `prefers-color-scheme`. So the fix is to use the light-only styling for now. If we ever implement dark mode, we can change this back. After the fix:
<img width="1039" alt="image" src="https://github.com/dguo/make-a-readme/assets/2763135/93f255db-44dc-4e00-a4fc-3dac9c4860bc">
